### PR TITLE
Fix typo in the comment posted in new default repository PRs

### DIFF
--- a/src/plugins/pull_request.labeled.new_default_repository.ts
+++ b/src/plugins/pull_request.labeled.new_default_repository.ts
@@ -13,7 +13,7 @@ Your repository is now waiting to be included in HACS. Please be patient, this w
 There is no need to:
 - Comment on the PR, the reviewer will get back to you.
 - Open a new PR, this will not speed up the process.
-- Ask your folowers to spam the PR, this will not speed up the process.
+- Ask your followers to spam the PR, this will not speed up the process.
 `
 
 export default async (


### PR DESCRIPTION
I've noticed a small typo in the message posted on PRs adding new repositories to https://github.com/hacs/default, so this PR aims to fix that. 